### PR TITLE
Add logic for AppointmentTime parser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/TimeParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.AppointmentTime;
+
+/**
+ * Parses input arguments and creates a new AppointmentTime object
+ */
+public class TimeParser {
+    /**
+     * The ideal format for an AppointmentTime is:
+     * dd/MM/yyyy [x]am-[y]pm
+     */
+    private static final Pattern DAY =
+            Pattern.compile("(0[1-9]|[12][0-9]|3[01])\\/(0[1-9]|1[012])\\/(2[0-9]{3})");
+    private static final Pattern HOUR = Pattern.compile("([1-9]|1[0-2])(?i)[ap]m");
+    private static final Pattern HOUR_WINDOW = Pattern.compile(HOUR + "([ ]?-[ ]?)" + HOUR);
+    private static final Pattern APPOINTMENT_TIME = Pattern.compile(DAY + " " + HOUR_WINDOW);
+    private static final String MESSAGE_USAGE = "Use dd/MM/yyyy [x]am-[y]pm";
+
+    /**
+     * To be very honest I have no idea what args would look like, I'm following the format
+     * of the other Parser subclasses in this package. This portion needs some severe
+     * rewriting in the future - JY
+     *
+     * Checks that the message follows the correct format.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AppointmentTime parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeParser.MESSAGE_USAGE));
+        }
+
+        Matcher matcher = TimeParser.APPOINTMENT_TIME.matcher(args);
+        if (!matcher.matches()) {
+            throw new ParseException("Filler");
+        }
+        return new AppointmentTime(args);
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -1,0 +1,45 @@
+package seedu.address.model.appointment;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Represents an Appointment in the address book.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Appointment {
+
+    // Data fields
+    private final UUID id;
+    private final Person person;
+    private final AppointmentTime appointmentTime;
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Appointment(Person person, AppointmentTime appointmentTime) {
+        this.id = UUID.randomUUID();
+        this.appointmentTime = appointmentTime;
+        this.person = person;
+    }
+
+    public UUID getUUID() {
+        return id;
+    }
+
+}

--- a/src/main/java/seedu/address/model/appointment/AppointmentTime.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentTime.java
@@ -1,0 +1,57 @@
+package seedu.address.model.appointment;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Represents an Appointment's email in the address book.
+ * ASSUMPTION: An Appointment CANNOT SPAN MULTIPLE DAYS!!!
+ * Guarantees: none at the moment.
+ */
+public class AppointmentTime {
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private final LocalDate appointmentDate;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+
+    /**
+     * Constructor for an AppointmentTime object.
+     * @param time Follow the format "dd/MM/yyyy [x]am-[y]pm".
+     */
+    public AppointmentTime(String time) {
+        String dateString = time.substring(0, 10); // first 10 chars is the date
+        String rawTimings = time.substring(11);
+        String[] timings = rawTimings.toUpperCase().split("-"); // each time will be "AM" or "PM" now
+        String startTime = timings[0].trim();
+        String endTime = timings[1].trim();
+        this.appointmentDate = LocalDate.parse(dateString, AppointmentTime.DATE_FORMAT);
+        this.startTime = parseRawTiming(startTime);
+        this.endTime = parseRawTiming(endTime);
+    }
+
+    private LocalTime parseRawTiming(String rawTime) {
+        int length = rawTime.length();
+        if (length == 4) {
+            int num = Integer.parseInt(rawTime.substring(0, 2));
+            if (rawTime.charAt(2) == 'A') { // AM
+                return LocalTime.of(num, 0);
+            } else { // PM
+                return LocalTime.of(12 + num, 0);
+            }
+        } else {
+            int num = Integer.parseInt(rawTime.substring(0, 1));
+            if (rawTime.charAt(1) == 'A') { // AM
+                return LocalTime.of(num, 0);
+            } else { // PM
+                return LocalTime.of(12 + num, 0);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "YOU";
+    }
+}


### PR DESCRIPTION
Skeletal `Appointment.java` class added.

This PR focuses on the `AppointmentTime` class and its parser. One key assumption is that an Appointment must be within a single day, i.e., there are no super long appointments that span multiple days (e.g., Friday 11pm to Saturday 1am is not allowed - respect working hours!!). A short regex parser is written to convert a string into an AppointmentTime, and the `AppointmentTime` object stores three variables:

LocalDate appointmentDate
LocalTime startTime
LocalTime endTime