### PR TITLE
Add `editappt` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/appointment/EditAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/appointment/EditAppointmentCommand.java
@@ -1,0 +1,168 @@
+package seedu.address.logic.commands.appointment;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentTime;
+
+/**
+ * Edits the details of an existing appointment in the address book.
+ */
+public class EditAppointmentCommand extends Command {
+
+    public static final String COMMAND_WORD = "editappt";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the appointment identified "
+            + "by the index number used in the displayed appointment list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_DATE + "DATE]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_DATE + "15/03/2024 9AM-2PM ";
+    public static final String MESSAGE_EDIT_APPOINTMENT_SUCCESS = "Edited Appointment: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "Date needs to be edited.";
+    public static final String MESSAGE_DUPLICATE_APPOINTMENT = "This appointment already exists in the address book.";
+
+    private final Index index;
+    private final EditAppointmentDescriptor editAppointmentDescriptor;
+
+    /**
+     * @param index of the appointment in the filtered appointment list to edit
+     * @param editAppointmentDescriptor details to edit the appointment with
+     */
+    public EditAppointmentCommand(Index index, EditAppointmentDescriptor editAppointmentDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editAppointmentDescriptor);
+
+        this.index = index;
+        this.editAppointmentDescriptor = new EditAppointmentDescriptor(editAppointmentDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Appointment> lastShownList = model.getFilteredAppointmentList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX);
+        }
+
+        Appointment appointmentToEdit = lastShownList.get(index.getZeroBased());
+        Appointment editedAppointment = createEditedAppointment(appointmentToEdit, editAppointmentDescriptor);
+
+        if (model.hasAppointment(editedAppointment)) {
+            throw new CommandException(MESSAGE_DUPLICATE_APPOINTMENT);
+        }
+
+        model.setAppointment(appointmentToEdit, editedAppointment);
+        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
+        return new CommandResult(String.format(MESSAGE_EDIT_APPOINTMENT_SUCCESS,
+                Messages.formatAppointment(editedAppointment)));
+    }
+
+    /**
+     * Creates and returns a {@code Appointment} with the details of {@code AppointmentToEdit}
+     * edited with {@code editAppointmentDescriptor}.
+     */
+    private static Appointment createEditedAppointment(Appointment appointmentToEdit,
+                                                       EditAppointmentDescriptor editAppointmentDescriptor) {
+        assert editAppointmentDescriptor != null;
+
+        AppointmentTime updatedAppointmentTime = editAppointmentDescriptor.getAppointmentTime()
+                .orElse(appointmentToEdit.getAppointmentTime());
+        return new Appointment(appointmentToEdit.getPersonId(), updatedAppointmentTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditAppointmentCommand)) {
+            return false;
+        }
+
+        EditAppointmentCommand otherEditCommand = (EditAppointmentCommand) other;
+        return index.equals(otherEditCommand.index)
+                && editAppointmentDescriptor.equals(otherEditCommand.editAppointmentDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("editAppointmentDescriptor", editAppointmentDescriptor)
+                .toString();
+    }
+
+    /**
+     * Stores the details to edit the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class EditAppointmentDescriptor {
+        private AppointmentTime appointmentTime;
+
+        public EditAppointmentDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditAppointmentDescriptor(EditAppointmentDescriptor toCopy) {
+            setAppointmentTime(toCopy.appointmentTime);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(appointmentTime);
+        }
+
+        public void setAppointmentTime(AppointmentTime appointmentTime) {
+            this.appointmentTime = appointmentTime;
+        }
+
+        public Optional<AppointmentTime> getAppointmentTime() {
+            return Optional.ofNullable(appointmentTime);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditAppointmentDescriptor)) {
+                return false;
+            }
+
+            EditAppointmentDescriptor othereditAppointmentDescriptor = (EditAppointmentDescriptor) other;
+            return Objects.equals(appointmentTime, othereditAppointmentDescriptor.appointmentTime);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("appointment time", appointmentTime)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/appointment/EditAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/appointment/EditAppointmentCommand.java
@@ -84,7 +84,7 @@ public class EditAppointmentCommand extends Command {
 
         AppointmentTime updatedAppointmentTime = editAppointmentDescriptor.getAppointmentTime()
                 .orElse(appointmentToEdit.getAppointmentTime());
-        return new Appointment(appointmentToEdit.getPersonId(), updatedAppointmentTime);
+        return new Appointment(appointmentToEdit.getId(), appointmentToEdit.getPersonId(), updatedAppointmentTime);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/appointment/EditAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/appointment/EditAppointmentCommand.java
@@ -112,8 +112,8 @@ public class EditAppointmentCommand extends Command {
     }
 
     /**
-     * Stores the details to edit the person with. Each non-empty field value will replace the
-     * corresponding field value of the person.
+     * Stores the details to edit the Appointment with.
+     * The appointmentTime must be replaced with a new date/time.
      */
     public static class EditAppointmentDescriptor {
         private AppointmentTime appointmentTime;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.appointment.AddAppointmentCommand;
 import seedu.address.logic.commands.appointment.DeleteAppointmentCommand;
+import seedu.address.logic.commands.appointment.EditAppointmentCommand;
 import seedu.address.logic.commands.appointment.ListAppointmentCommand;
 import seedu.address.logic.commands.person.AddPersonCommand;
 import seedu.address.logic.commands.person.DeletePersonCommand;
@@ -22,6 +23,7 @@ import seedu.address.logic.commands.person.FindPersonCommand;
 import seedu.address.logic.commands.person.ListPersonCommand;
 import seedu.address.logic.parser.appointment.AddAppointmentCommandParser;
 import seedu.address.logic.parser.appointment.DeleteAppointmentCommandParser;
+import seedu.address.logic.parser.appointment.EditAppointmentCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.person.AddPersonCommandParser;
 import seedu.address.logic.parser.person.DeletePersonCommandParser;
@@ -84,6 +86,9 @@ public class AddressBookParser {
 
         case DeleteAppointmentCommand.COMMAND_WORD:
             return new DeleteAppointmentCommandParser().parse(arguments);
+
+        case EditAppointmentCommand.COMMAND_WORD:
+            return new EditAppointmentCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/appointment/EditAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/appointment/EditAppointmentCommandParser.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser.appointment;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.appointment.EditAppointmentCommand;
+import seedu.address.logic.commands.appointment.EditAppointmentCommand.EditAppointmentDescriptor;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.TimeParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditAppointmentCommand object
+ */
+public class EditAppointmentCommandParser implements Parser<EditAppointmentCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditAppointmentCommand
+     * and returns an EditAppointmentCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditAppointmentCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DATE);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditAppointmentCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE);
+
+        EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptor();
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            editAppointmentDescriptor.setAppointmentTime(TimeParser.parse(argMultimap.getValue(PREFIX_DATE).get()));
+        }
+        if (!editAppointmentDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditAppointmentCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditAppointmentCommand(index, editAppointmentDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -71,10 +71,9 @@ public class Appointment {
         }
 
         Appointment otherAppointment = (Appointment) other;
-        boolean sameID = id.equals(otherAppointment.getId());
         boolean samePersonId = personId.equals(otherAppointment.getPersonId());
         boolean sameDate = appointmentTime.equals(otherAppointment.getAppointmentTime());
-        return (sameID && samePersonId && sameDate);
+        return (samePersonId && sameDate);
     }
 
 }


### PR DESCRIPTION
An `editappt` command can be used to edit the date and time of an appointment shown in the appointment list.

Input format: `editappt INDEX d/DATETIME`
Example:  `editappt 1 d/18/03/2024 9am-10am` will change the previous date of the first appointment in the appointment list to 18/03/2024 9am-10am.

resolves #49 