### PR TITLE
Add ImportCommand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
 
 	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
 	implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
+	// https://mavenlibs.com/maven/dependency/com.opencsv/opencsv
+	implementation group: 'com.opencsv', name: 'opencsv', version: '5.8'
 
 	testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
@@ -67,7 +69,7 @@ dependencies {
 }
 
 shadowJar {
-	archiveFileName = 'addressbook.jar'
+	archiveFileName = 'RapidTracer.jar'
 }
 
 spotless {

--- a/src/main/java/seedu/address/logic/commands/person/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/ImportCommand.java
@@ -1,0 +1,169 @@
+package seedu.address.logic.commands.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_IMPORT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.opencsv.CSVParser;
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvException;
+
+import seedu.address.commons.exceptions.DataLoadingException;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.person.AddPersonCommandParser;
+import seedu.address.model.Model;
+
+/**
+ * Import data from a csv file to the address book.
+ */
+public class ImportCommand extends Command {
+
+    public static final String COMMAND_WORD = "import";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports patient contacts from a given csv file"
+            + "Parameters: FILEPATH...\n"
+            + "Example: " + COMMAND_WORD + PREFIX_IMPORT + "./data/patient.csv";
+
+    public static final String MESSAGE_SUCCESS = "Imported patient contact from: %1$s";
+    public static final String MESSAGE_LOADING_ERROR = "Import failed due to data loading error. Please try again.";
+    public static final String MESSAGE_FORMAT_ERROR = "Import failed due to format error.";
+
+    private final Path filePath;
+    private final AddPersonCommandParser addPersonCommandParser = new AddPersonCommandParser();
+
+    private final String[] fields = {"name", "phone", "address", "tags"};
+
+    private final Map<String, Prefix> prefixMap = Map.of(
+            "name", PREFIX_NAME,
+            "phone", PREFIX_PHONE,
+            "address", PREFIX_ADDRESS,
+            "tags", PREFIX_TAG);
+
+    /**
+     * The ImportCommand object takes in a specified file.
+     * @param filePath the absolute path of the file
+     */
+    public ImportCommand(Path filePath) {
+        requireNonNull(filePath);
+
+        this.filePath = filePath;
+    }
+
+    /**
+     * Adds person contact data to the address book from the csv file line by line.
+     * @param model {@code Model} which the command should operate on.
+     * @return CommandResult
+     * @throws CommandException formatting or data loading errors will be notified.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        try {
+            List<Map<String, String>> data = readFile();
+            for (Map<String, String> patientDetail : data) {
+                try {
+                    String addPersonCommandInput = convertToAddPersonCommandInput(patientDetail);
+                    AddPersonCommand addPersonCommand = parseAddPersonCommand(addPersonCommandInput);
+                    addPersonCommand.execute(model);
+                } catch (ParseException e) {
+                    throw new CommandException(MESSAGE_FORMAT_ERROR);
+                }
+            }
+        } catch (DataLoadingException e) {
+            throw new CommandException(MESSAGE_LOADING_ERROR);
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, filePath.toString()));
+    }
+
+    /**
+     * Uses OpenCSV API to read in patient data from a csv file and returns a list of maps.
+     * @throws DataLoadingException notifies if error occurs
+     */
+    public List<Map<String, String>> readFile() throws DataLoadingException {
+        try (Reader reader = Files.newBufferedReader(filePath)) {
+            CSVParser parser = new CSVParserBuilder().build();
+            CSVReader csvReader = new CSVReaderBuilder(reader).withCSVParser(parser).build();
+            List<String[]> rows = csvReader.readAll();
+            List<Map<String, String>> details = new ArrayList<>();
+            String[] fields = rows.get(0);
+            for (int i = 1; i < rows.size(); i++) {
+                String[] row = rows.get(i);
+                Map<String, String> map = new HashMap<>();
+                for (int j = 0; j < fields.length; j++) {
+                    map.put(fields[j], row[j]);
+                }
+                details.add(map);
+            }
+            return details;
+        } catch (IOException | CsvException e) {
+            throw new DataLoadingException(e);
+        }
+    }
+
+    /**
+     * Converts a map of patient data to a string that can be parsed by the addPersonCommandParser
+     * @param patientDetail
+     * @return
+     */
+    public String convertToAddPersonCommandInput(Map<String, String> patientDetail) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(" ");
+        for (String key : fields) {
+            if (patientDetail.get(key).isEmpty()) {
+                continue;
+            }
+            if (key.equals("tags")) {
+                String tags = patientDetail.get(key);
+                String[] tagSet = tags.split(";");
+                for (String tagName : tagSet) {
+                    sb.append(prefixMap.get(key).getPrefix());
+                    sb.append(tagName);
+                    sb.append(" ");
+                }
+            } else {
+                sb.append(prefixMap.get(key).getPrefix());
+                sb.append(patientDetail.get(key));
+            }
+            sb.append(" ");
+        }
+        return sb.toString();
+    }
+
+    public AddPersonCommand parseAddPersonCommand(String input) throws ParseException {
+        return addPersonCommandParser.parse(input);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ImportCommand)) {
+            return false;
+        }
+
+        ImportCommand e = (ImportCommand) other;
+        return filePath.equals(e.filePath);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.person.AddPersonCommand;
 import seedu.address.logic.commands.person.DeletePersonCommand;
 import seedu.address.logic.commands.person.EditPersonCommand;
 import seedu.address.logic.commands.person.FindPersonCommand;
+import seedu.address.logic.commands.person.ImportCommand;
 import seedu.address.logic.commands.person.ListPersonCommand;
 import seedu.address.logic.parser.appointment.AddAppointmentCommandParser;
 import seedu.address.logic.parser.appointment.DeleteAppointmentCommandParser;
@@ -32,6 +33,7 @@ import seedu.address.logic.parser.person.AddPersonCommandParser;
 import seedu.address.logic.parser.person.DeletePersonCommandParser;
 import seedu.address.logic.parser.person.EditPersonCommandParser;
 import seedu.address.logic.parser.person.FindPersonCommandParser;
+import seedu.address.logic.parser.person.ImportCommandParser;
 import seedu.address.model.appointment.FindAppointmentCommand;
 /**
  * Parses user input.
@@ -108,6 +110,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_IMPORT = new Prefix("i/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -105,4 +107,17 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses a {@code String filePath} into a {@code filePath}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code filePath} is invalid.
+     */
+    public static Path parseFilePath(String filePath) throws ParseException {
+        requireNonNull(filePath);
+        String trimmedFile = filePath.trim();
+        return Paths.get(trimmedFile);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/person/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/ImportCommandParser.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser.person;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_IMPORT;
+
+import java.nio.file.Path;
+
+import seedu.address.logic.commands.person.ImportCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ImportCommand object
+ */
+public class ImportCommandParser implements Parser<ImportCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ImportCommand
+     * and returns an ImportCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ImportCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_IMPORT);
+
+        if (!arePrefixesPresent(argMultimap)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        }
+
+        Path path = ParserUtil.parseFilePath(argMultimap.getValue(PREFIX_IMPORT).orElse(""));
+        return new ImportCommand(path);
+
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap) {
+        return argumentMultimap.getValue(PREFIX_IMPORT).isPresent();
+    }
+}


### PR DESCRIPTION
A new command to import patient details from a csv file is added.

Input format: import i/filepath
The filepath should be an absolute filepath
The file should be a csv file.

Example:  import i/C:\Users\Desktop\CS2103T\tP\src\test\data\sample.csv

Bugs to be fixed: 
Existing patients preempt the import process. 
Empty lines preempt the import process. 
