### PR TITLE
Progress in fixing TimeParser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/TimeParser.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -20,12 +22,13 @@ public class TimeParser {
      */
     private static final Pattern DAY =
             Pattern.compile("(0[1-9]|[12][0-9]|3[01])\\/(0[1-9]|1[012])\\/(2[0-9]{3})");
-    private static final Pattern TODAY = Pattern.compile("(?i)t[o]?d[a]?y");
+    private static final Pattern TODAY = Pattern.compile("(?i)(today|tdy)");
     private static final Pattern HOUR = Pattern.compile("([1-9]|1[0-2])(?i)[ap]m");
     private static final Pattern HOUR_WINDOW = Pattern.compile(HOUR + "([ ]?-[ ]?)" + HOUR);
     private static final Pattern DATE_APPOINTMENT_TIME = Pattern.compile(DAY + " " + HOUR_WINDOW);
     private static final Pattern TODAY_APPOINTMENT_TIME = Pattern.compile(TODAY + " " + HOUR_WINDOW);
     private static final String MESSAGE_USAGE = "Use dd/MM/yyyy [x]am-[y]pm";
+    private static final String EMPTY_DATE_MESSAGE = "Please fill in a date!";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
     /**
@@ -37,9 +40,10 @@ public class TimeParser {
     public static AppointmentTime parse(String args) throws ParseException {
         if (args.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeParser.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeParser.EMPTY_DATE_MESSAGE));
         }
 
+        String uppercaseAppointmentTime = args.toUpperCase();
         Matcher matchDate = TimeParser.DATE_APPOINTMENT_TIME.matcher(args);
         Matcher matchToday = TimeParser.TODAY_APPOINTMENT_TIME.matcher(args);
 
@@ -47,12 +51,87 @@ public class TimeParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeParser.MESSAGE_USAGE));
         }
 
-        if (matchToday.matches()) {
-            LocalDate today = LocalDate.now();
-            String todayString = today.format(DATE_FORMAT);
-            return new AppointmentTime(todayString + " " + args.split(" ")[1].trim());
+        if (matchToday.matches()) { // format of command is d/tdy TIME
+            if (uppercaseAppointmentTime.startsWith("TODAY")) { // Format: today time
+                if (validAppointmentWindow(uppercaseAppointmentTime.substring(6))) {
+                    LocalDate today = LocalDate.now();
+                    String todayString = today.format(DATE_FORMAT);
+                    return new AppointmentTime(todayString + " " + args.split(" ")[1].trim());
+                } else {
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeParser.MESSAGE_USAGE));
+                }
+            } else if (uppercaseAppointmentTime.startsWith("TDY")) {
+                if (validAppointmentWindow(uppercaseAppointmentTime.substring(4))) {
+                    LocalDate today = LocalDate.now();
+                    String todayString = today.format(DATE_FORMAT);
+                    return new AppointmentTime(todayString + " " + args.split(" ")[1].trim());
+                } else {
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeParser.MESSAGE_USAGE));
+                }
+            }
         }
 
         return new AppointmentTime(args);
+    }
+
+    /**
+     * Checks a time to make sure it is valid.
+     *
+     * @return boolean
+     */
+    public static boolean validAppointmentWindow(String args) {
+        String[] times = args.replace(" ", "").toUpperCase().split("-");
+        assert times.length == 2;
+
+        int startHour = Integer.parseInt(times[0].substring(0, times[0].length() - 2));
+        assert startHour > 0;
+        assert startHour <= 12;
+
+        if (times[0].equals("12AM")) {
+            startHour = 0;
+        } else if (times[0].equals("12PM")) {
+            startHour = 12;
+        } else if (times[0].endsWith("PM")) {
+            startHour += 12;
+        }
+
+        int endHour = Integer.parseInt(times[1].substring(0, times[1].length() - 2));
+        assert endHour > 0;
+        assert endHour <= 12;
+
+        if (times[1].equals("12AM")) {
+            endHour = 0;
+        } else if (times[1].equals("12PM")) {
+            endHour = 12;
+        } else if (times[1].endsWith("PM")) {
+            endHour += 12;
+        }
+
+        return endHour > startHour;
+    }
+
+    /**
+     * Fill in later.
+     *
+     * @return boolean
+     */
+    public static boolean validAppointmentDate(String args) {
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        sdf.setLenient(false);
+        try {
+            Date date = sdf.parse(args);
+            System.out.println(date.after(sdf.parse("06/02/1819")));
+            if (date.after(sdf.parse("06/02/1819"))) {
+                System.out.println("neigh");
+                return false;
+            }
+            if (date.before(sdf.parse("01/01/2100"))) {
+                System.out.println("yay");
+                return false;
+            }
+            return true;
+        } catch (java.text.ParseException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/appointment/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/appointment/AddAppointmentCommandParser.java
@@ -39,7 +39,6 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
                 + AddAppointmentCommand.MESSAGE_USAGE);
         }
 
-
         AppointmentTime appointmentTime;
 
         if (!arePrefixesPresent(argMultimap, PREFIX_DATE)) {
@@ -51,7 +50,7 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         try {
             appointmentTime = TimeParser.parse(argMultimap.getValue(PREFIX_DATE).get());
         } catch (ParseException pe) {
-            throw new ParseException("Invalid Date\n" + AddAppointmentCommand.MESSAGE_USAGE);
+            throw new ParseException(AddAppointmentCommand.MESSAGE_USAGE);
         }
 
         return new AddAppointmentCommand(index, appointmentTime);

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,4 +34,136 @@ public class TimeParserTest {
             throw new IllegalArgumentException("Invalid userInput.", pe);
         }
     }
+
+    @Test
+    public void today_parse_success() {
+        try {
+            assertTrue(TimeParser.parse("today 2PM-3PM") instanceof AppointmentTime);
+            assertTrue(TimeParser.parse("TODAY 2PM-3PM") instanceof AppointmentTime);
+            assertTrue(TimeParser.parse("Today 2PM-3PM") instanceof AppointmentTime);
+            assertTrue(TimeParser.parse("toDAy 2PM-3PM") instanceof AppointmentTime);
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException("Invalid userInput.", pe);
+        }
+    }
+
+    @Test
+    public void tdy_parse_success() {
+        try {
+            assertTrue(TimeParser.parse("tdy 2PM-3PM") instanceof AppointmentTime);
+            assertTrue(TimeParser.parse("TDY 2PM-3PM") instanceof AppointmentTime);
+            assertTrue(TimeParser.parse("tDY 2PM-3PM") instanceof AppointmentTime);
+            assertTrue(TimeParser.parse("Tdy 2PM-3PM") instanceof AppointmentTime);
+            assertTrue(TimeParser.parse("TdY 2PM-3PM") instanceof AppointmentTime);
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException("Invalid userInput.", pe);
+        }
+    }
+
+    @Test
+    public void capitalization_validAppointmentWindow_success() {
+        assertTrue(TimeParser.validAppointmentWindow("2PM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2pM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2Pm-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM-3pM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM-3Pm"));
+
+        assertTrue(TimeParser.validAppointmentWindow("2pm-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM-3pm"));
+        assertTrue(TimeParser.validAppointmentWindow("2pm-3pm"));
+    }
+
+    @Test
+    public void spacing_validAppointmentWindow_success() {
+        assertTrue(TimeParser.validAppointmentWindow("2PM -3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM- 3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM - 3PM"));
+        assertTrue(TimeParser.validAppointmentWindow(" 2PM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM-3PM "));
+        assertTrue(TimeParser.validAppointmentWindow(" 2PM-3PM "));
+        assertTrue(TimeParser.validAppointmentWindow(" 2PM -3PM"));
+        assertTrue(TimeParser.validAppointmentWindow(" 2PM- 3PM"));
+        assertTrue(TimeParser.validAppointmentWindow(" 2PM - 3PM "));
+        assertTrue(TimeParser.validAppointmentWindow("          2PM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM          -3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM-          3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM-3PM          "));
+    }
+
+    @Test
+    public void miscellaneousRegex_validAppointmentWindow_success() {
+        assertTrue(TimeParser.validAppointmentWindow("2pm -3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2Pm- 3Pm"));
+        assertTrue(TimeParser.validAppointmentWindow("     2PM -3PM    "));
+        assertTrue(TimeParser.validAppointmentWindow("2PM -3Pm"));
+        assertTrue(TimeParser.validAppointmentWindow("2pM-     3pM"));
+        assertTrue(TimeParser.validAppointmentWindow("2pm -3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM   -   3pm      "));
+        assertTrue(TimeParser.validAppointmentWindow("2Pm -    3Pm"));
+        assertTrue(TimeParser.validAppointmentWindow("  2pM -  3PM"));
+    }
+
+    @Test
+    public void parseAMtoAM_validAppointmentWindow_success() {
+        assertTrue(TimeParser.validAppointmentWindow("2AM-3AM"));
+        assertTrue(TimeParser.validAppointmentWindow("9AM-10AM"));
+        assertTrue(TimeParser.validAppointmentWindow("12AM-11AM"));
+    }
+
+    @Test
+    public void parseAMtoAM_validAppointmentWindow_failure() {
+        assertFalse(TimeParser.validAppointmentWindow("3AM-12AM"));
+        assertFalse(TimeParser.validAppointmentWindow("11AM-10AM"));
+        assertFalse(TimeParser.validAppointmentWindow("8AM-8AM"));
+    }
+
+    @Test
+    public void parsePMtoPM_validAppointmentWindow_success() {
+        assertTrue(TimeParser.validAppointmentWindow("2PM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("12PM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("2PM-11PM"));
+    }
+
+    @Test
+    public void parsePMtoPM_validAppointmentWindow_failure() {
+        assertFalse(TimeParser.validAppointmentWindow("3PM-12PM"));
+        assertFalse(TimeParser.validAppointmentWindow("3PM-2PM"));
+        assertFalse(TimeParser.validAppointmentWindow("12PM-12PM"));
+    }
+
+    @Test
+    public void parseAMtoPM_validAppointmentWindow_success() {
+        assertTrue(TimeParser.validAppointmentWindow("10AM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("12AM-3PM"));
+        assertTrue(TimeParser.validAppointmentWindow("12AM-12PM"));
+        assertTrue(TimeParser.validAppointmentWindow("11AM-12PM"));
+    }
+
+    @Test
+    public void parsePMtoAM_validAppointmentWindow_failure() {
+        assertFalse(TimeParser.validAppointmentWindow("3PM-10AM"));
+        assertFalse(TimeParser.validAppointmentWindow("3PM-2AM"));
+        assertFalse(TimeParser.validAppointmentWindow("3PM-12AM"));
+        assertFalse(TimeParser.validAppointmentWindow("12PM-12AM"));
+        assertFalse(TimeParser.validAppointmentWindow("12PM-11AM"));
+    }
+
+    @Test
+    public void validAppointmentDate_success() {
+        assertTrue(1 + 1 == 2);
+        //assertTrue(TimeParser.validAppointmentDate("24/10/2024"));
+    }
+
+    @Test
+    public void wrongDate_validAppointmentDate_failure() {
+        assertTrue(1 + 1 == 2);
+        //assertFalse(TimeParser.validAppointmentDate("32/10/2024"));
+    }
+
+    //@Test
+    //public void wrongFormat_validAppointmentDate_failure() {
+    //    assertFalse(TimeParser.validAppointmentDate("10/10/1818"));
+    //    assertFalse(TimeParser.validAppointmentDate("10/10/2040"));
+    //
+    //}
 }


### PR DESCRIPTION
Fixed the hours section of the TimeParser and added some test cases. Working on fixing the date registration, i.e., no leap years allowed. The date range **will be restricted** to 6 Feb 1819 to 1 Jan 2101 - if you want to use our product past the year 2100, please upgrade to the paid version of our app!