### PR TITLE
Restore search by UUID for appointment

### DIFF
--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsKeywordsPredicate.java
@@ -54,7 +54,8 @@ public class AppointmentContainsKeywordsPredicate implements Predicate<Appointme
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
                         model.getPersonById(
                                 appointment.getPersonId()).getName().fullName,
-                        keyword));
+                        keyword)
+                        || appointment.getPersonIdString().equals(keyword));
     }
 
     @Override


### PR DESCRIPTION
Fix the previous blunder of removing the UUID as a predicate filter for findappt. However we do not need to specify this in the user guide right? I removed it from UG yesterday, since it shouldn't be helpful for users to search by UUID?